### PR TITLE
fix: add TRAEFIK_DYNAMIC_DIR env var and volume mount for custom domain routing

### DIFF
--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -197,9 +197,16 @@ services:
       - PUBLISHER_HOST=${PUBLISHER_HOST:-wstd.work}
       - BUILDER_INTERNAL_URL=http://app:3000
       - PROXY_PORT=4001
+      # Enables auto-generation of Traefik dynamic config files for custom domains.
+      # The publisher writes one YAML file per custom domain so Traefik can route
+      # traffic and request a Let's Encrypt certificate automatically.
+      - TRAEFIK_DYNAMIC_DIR=/data/coolify/proxy/dynamic
     volumes:
       - published-sites:/var/publish
       - publisher-work:/var/work
+      # Required for TRAEFIK_DYNAMIC_DIR: gives the publisher write access to the
+      # Traefik file-provider directory so it can create per-domain route configs.
+      - /data/coolify/proxy/dynamic:/data/coolify/proxy/dynamic:rw
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:4000/health || exit 1"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,6 +126,11 @@ services:
       PUBLISHER_HOST: ${PUBLISHER_HOST:-}
       BUILDER_INTERNAL_URL: http://app:3000
       PROXY_PORT: "4001"
+      # Optional: set to your Traefik file-provider directory to enable auto-generation
+      # of per-domain route configs for custom domains (with TLS via Let's Encrypt).
+      # Example: TRAEFIK_DYNAMIC_DIR=/etc/traefik/dynamic
+      # Also add a bind mount below: - ${TRAEFIK_DYNAMIC_DIR}:${TRAEFIK_DYNAMIC_DIR}:rw
+      TRAEFIK_DYNAMIC_DIR: ${TRAEFIK_DYNAMIC_DIR:-}
     volumes:
       - published-sites:/var/publish
       - publisher-work:/var/work


### PR DESCRIPTION
## Problem

`TRAEFIK_DYNAMIC_DIR` was not set in the publisher's environment, so `writeTraefikRouteForDomain` was a no-op on every custom domain publish. Custom domains therefore had no Traefik route and all requests fell through to the catchall `noop` service → **"no available server"** (503).

## Fix

**`docker-compose.coolify.yml`**
- Set `TRAEFIK_DYNAMIC_DIR=/data/coolify/proxy/dynamic` (Coolify's Traefik file-provider path)
- Add bind mount `/data/coolify/proxy/dynamic` in `rw` mode so the publisher can write YAML files at publish time

**`docker-compose.yml`**
- Expose `TRAEFIK_DYNAMIC_DIR: ${TRAEFIK_DYNAMIC_DIR:-}` as an optional env var (empty by default — no Traefik required in the classic setup)
- Comment documents how to add the bind mount when using an external Traefik

## Test plan

- [ ] Redeploy publisher service in Coolify
- [ ] Publish a project with a custom domain
- [ ] Verify `<domain>.yaml` appears in `/data/coolify/proxy/dynamic/`
- [ ] Verify the custom domain is accessible (no "no available server")